### PR TITLE
remove unnecessary checking activated neutron port when using macvlan

### DIFF
--- a/kuryr_kubernetes/os_vif_util.py
+++ b/kuryr_kubernetes/os_vif_util.py
@@ -290,7 +290,7 @@ def neutron_to_osvif_vif_nested_macvlan(neutron_port, subnets):
         network=_make_vif_network(neutron_port, subnets),
         has_traffic_filtering=details.get('port_filter', False),
         preserve_on_delete=False,
-        active=_is_port_active(neutron_port),
+        active=True,
         plugin=const.K8S_OS_VIF_NOOP_PLUGIN,
         vif_name=_get_vif_name(neutron_port))
 


### PR DESCRIPTION
Macvlan does not need to wait for activating neutron port.
It need only IP address and MAC address.
So, waiting for "_is_port_active()" is not needed.

"_is_port_active()" cause unnecessary waiting time.